### PR TITLE
Enable gitleaks hook in pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -58,7 +58,7 @@ repos:
 
   # GO-based
   - repo: https://github.com/gitleaks/gitleaks
-    rev: v8.30.0
+    rev: v8.30.1
     hooks:
       - id: gitleaks
         name: Run gitleaks


### PR DESCRIPTION
Uncomment gitleaks configuration to enable secret checks.