### PR TITLE
Configure Dependabot for Bun package updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,18 @@
 ---
 version: 2
 updates:
+  - package-ecosystem: 'bun'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+    open-pull-requests-limit: 3
+    groups:
+      bun-dependencies:
+        patterns:
+          - '*'
+    cooldown:
+      default-days: 7
+
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:


### PR DESCRIPTION
Added support for Bun package ecosystem updates with a weekly schedule and a limit of 3 open pull requests.